### PR TITLE
fix(home): fix parse openNow

### DIFF
--- a/src/views/Home.vue
+++ b/src/views/Home.vue
@@ -26,7 +26,7 @@
           :address="store.address"
           :distance="store.matrix.distance"
           :photo="store.place.photo"
-          :openNow="store.place.schedule.openNow"
+          :openNow="store.place.schedule ? store.place.schedule.openNow : false"
         />
       </transition-group>
     </div>


### PR DESCRIPTION
Es posible que el nodo `place.schedule` venga `null`, es por ello que se agrega validación en caso de no venir data. Para ese caso se deja como "cerrado" (`false`), pero debiese indicar que no hay info disponible.