### PR TITLE
fix(store): fix overflow toggle

### DIFF
--- a/src/views/Store.vue
+++ b/src/views/Store.vue
@@ -134,6 +134,7 @@ export default {
 
   beforeDestroy () {
     this.$store.commit('setInStore', false)
+    this.setBodyOverflow()
   },
 
   apollo: {
@@ -170,14 +171,16 @@ export default {
 
     toggleFullScreenMap () {
       this.isFullScreenMap = !this.isFullScreenMap
-
-      if (this.isFullScreenMap === true) {
-        document.getElementsByTagName('body')[0].style.overflow = 'hidden'
-      } else {
-        document.getElementsByTagName('body')[0].style.overflow = 'auto'
-      }
-
+      this.setBodyOverflow(this.isFullScreenMap)
       window.scrollTo(0, 0)
+    },
+
+    setBodyOverflow (value) {
+      if (value) {
+        document.querySelector('body').style.overflow = 'hidden'
+      } else {
+        document.querySelector('body').style.overflow = 'auto'
+      }
     }
   }
 }


### PR DESCRIPTION
Esto soluciona un fallo cuando estas con el mapa full screen y vuelves atrás sin cerrar "correctamente" el mapa, quedando el body con overflow: hidden. Ahora reinicia los valores y queda con los estilos 👌 